### PR TITLE
Remove amundsenfrontend build args

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,9 +59,6 @@ services:
   amundsenfrontend:
       build:
         context: .
-        args:
-          SEARCHSERVICE_BASE: http://amundsensearch:5001
-          METADATASERVICE_BASE: http://amundsenmetadata:5002
         dockerfile: Dockerfile.frontend
       container_name: amundsenfrontend
       depends_on:


### PR DESCRIPTION
When running the build locally, I got the following message for the frontend service:

```
[Warning] One or more build-args [SEARCHSERVICE_BASE METADATASERVICE_BASE] were not consumed
```

These args aren't specified in the frontend `Dockerfile` at all, and they're actually specified within the `environment` block of that same service: https://github.com/stemma-ai/amundsen-custom/blob/7dd1a5cee3caed0dbedbe0023533a777b37cec59/docker-compose.yml#L75-L76

This PR removes the `args` section so this warning goes away during the build.
