### PR TITLE
docker-compose: remove env var for FE config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,6 @@ services:
       environment:
         - SEARCHSERVICE_BASE=http://amundsensearch:5001
         - METADATASERVICE_BASE=http://amundsenmetadata:5002
-        - FRONTEND_SVC_CONFIG_MODULE_CLASS=amundsen_application.config.TestConfig
 
 networks:
   amundsennet:


### PR DESCRIPTION
`FRONTEND_SVC_CONFIG_MODULE_CLASS` is superfluous because we specify it directly in `wsgi.py`.

ty @madison-ookla 